### PR TITLE
Fix missing "contributes.debuggers[0].languages"

### DIFF
--- a/src/moonsharp-vscode-debug/package.json
+++ b/src/moonsharp-vscode-debug/package.json
@@ -88,7 +88,11 @@
                             }
                         }
                     }
-                }
+                    }
+                ],
+                "languages": [
+                    "lua"
+                ]
             }
         ],
         "languages": [


### PR DESCRIPTION
Fixes the VSC extension's `package.json` missing configuration to associate the debugger with Lua files.